### PR TITLE
Fixed moveit2 humble build

### DIFF
--- a/ros2/humble/kinova/Dockerfile
+++ b/ros2/humble/kinova/Dockerfile
@@ -113,7 +113,7 @@ RUN git clone https://github.com/ros-planning/moveit2.git -b ${ROS2_DISTRO}
 RUN git clone https://github.com/moveit/py_binding_tools.git -b ros2
 RUN for repo in moveit2/moveit2.repos $(f="moveit2/moveit2_${ROS2_DISTRO}.repos"; test -r $f && echo $f); do vcs import < "$repo"; done
 RUN rosdep install -r --from-paths . --ignore-src --rosdistro ${ROS2_DISTRO} -y
-RUN git clone https://github.com/moveit/moveit_task_constructor.git -b ${ROS2_DISTRO}
+#RUN git clone https://github.com/moveit/moveit_task_constructor.git -b ${ROS2_DISTRO}
 
 # Install middleware 
 RUN sudo apt install ros-${ROS2_DISTRO}-rmw-cyclonedds-cpp -y

--- a/ros2/humble/kinova/Dockerfile
+++ b/ros2/humble/kinova/Dockerfile
@@ -130,23 +130,21 @@ RUN git clone https://github.com/moveit/moveit2_tutorials.git -b ${ROS2_DISTRO}
 RUN git clone https://github.com/moveit/moveit_visual_tools.git -b ros2
 RUN git clone https://github.com/PickNikRobotics/graph_msgs.git -b ros2
 RUN git clone https://github.com/moveit/moveit_task_constructor.git -b ${ROS2_DISTRO}
-RUN git clone https://github.com/moveit/moveit_resources.git -b ros2
+#RUN git clone https://github.com/moveit/moveit_resources.git -b ros2
 WORKDIR ${COLCON_WS}
 RUN bash -c "source /opt/ros/humble/setup.sh; source ~/.bashrc; MAKEFLAGS="-j${nproc-1}" colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release"
 RUN echo "source ${COLCON_WS}/install/setup.bash" >> ~/.bashrc
 
 #RUN apt-get install -y libserial-dev
-RUN mkdir -p kortex2_ws/src
-WORKDIR /root/kortex2_ws/src
-RUN git clone https://github.com/tylerjw/serial.git 
-WORKDIR /root/kortex2_ws/src/serial 
-RUN git checkout ros2
-WORKDIR /root/kortex2_ws/src/
-RUN git clone https://github.com/PickNikRobotics/ros2_robotiq_gripper.git 
-RUN git clone https://github.com/PickNikRobotics/ros2_kortex.git 
-WORKDIR /root/kortex2_ws
+#RUN mkdir -p kortex2_ws/src
+#WORKDIR /root/kortex2_ws/src
+#WORKDIR /root/kortex2_ws/src/
+#RUN git clone https://github.com/PickNikRobotics/ros2_robotiq_gripper.git 
+#RUN vcs import src --skip-existing --input src/ros2_robotiq_gripper-not-released.humble.repos
+#RUN git clone https://github.com/PickNikRobotics/ros2_kortex.git 
+#WORKDIR /root/kortex2_ws
 #RUN rosdep install --ignore-src --from-paths src -y -r
-RUN bash -c "source /opt/ros/humble/setup.bash; colcon build"
-RUN echo "source /root/kortex2_ws/install/setup.bash" >> ~/.bashrc
+#RUN bash -c "source /opt/ros/humble/setup.bash; colcon build"
+#RUN echo "source /root/kortex2_ws/install/setup.bash" >> ~/.bashrc
 
 CMD ["bash"]

--- a/ros2/humble/kinova/Dockerfile
+++ b/ros2/humble/kinova/Dockerfile
@@ -110,6 +110,7 @@ WORKDIR ${COLCON_WS}/src
 
 # Download moveit2 source code
 RUN git clone https://github.com/ros-planning/moveit2.git -b ${ROS2_DISTRO}
+RUN git clone https://github.com/moveit/py_binding_tools.git -b ros2
 RUN for repo in moveit2/moveit2.repos $(f="moveit2/moveit2_${ROS2_DISTRO}.repos"; test -r $f && echo $f); do vcs import < "$repo"; done
 RUN rosdep install -r --from-paths . --ignore-src --rosdistro ${ROS2_DISTRO} -y
 RUN git clone https://github.com/moveit/moveit_task_constructor.git -b ${ROS2_DISTRO}


### PR DESCRIPTION
For some reason, building moveit2 started failing. 

Removed kinova packages, left only `moveit2` and `ROS 2` as basis for the dev. 